### PR TITLE
Allow multiple manifest files

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ export default defineConfig({
 })
 ```
 
+### Copying multiple manifests
+
+To copy multiple manifests to your output folder, define `officeAddin` entry for each file:
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite'
+import officeAddin from 'vite-plugin-office-addin'
+
+export default defineConfig({
+  plugins: [
+    officeAddin({ path: 'manifest.xml' }),
+    officeAddin({ path: 'manifest.staging.xml' }),
+  ]
+})
+```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ export default defineConfig({
 })
 ```
 
-### Advanced Usage
+## Advanced Usage
+
+### Replacing development address
 
 To replace the development URL address in **manifest.xml** file to production address,
 you can use the plugin configuration option or `.env` files.
@@ -70,6 +72,24 @@ ADDIN_PROD_URL=https://office-addin.contoso.com
 
 When you run `vite build` the generated **manifest.xml** file will have
 production addresses.
+
+
+### Specify a custom path
+
+If your `manifest.xml` file is not in the project root, set the `path` property to point to the right location:
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite'
+import officeAddin from 'vite-plugin-office-addin'
+
+export default defineConfig({
+  plugins: [officeAddin({
+    path: 'src/other-folder/manifest.xml'
+  })]
+})
+```
+
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,13 @@ import fs from 'fs'
 import path from 'path'
 
 export interface Options {
+  path?: string
   devUrl?: string
   prodUrl?: string
 }
 
 export default function officeManifest(options?: Options) : Plugin {
-  const manifestFile = 'manifest.xml'
+  const manifestFile = options?.path ?? 'manifest.xml'
 
   let viteConfig: ResolvedConfig
   let env : Record<string, string>
@@ -23,10 +24,10 @@ export default function officeManifest(options?: Options) : Plugin {
     },
 
     generateBundle() {
-      const manifestPath = path.resolve(viteConfig.root, 'manifest.xml')
+      const manifestPath = path.resolve(viteConfig.root, manifestFile)
 
       if (!fs.existsSync(manifestPath)) {
-        viteConfig.logger.warn('The manifest.xml file does not exists.')
+        viteConfig.logger.warn(`The manifest.xml file does not exist at path: '${manifestPath}'`)
         return
       }
 
@@ -40,7 +41,7 @@ export default function officeManifest(options?: Options) : Plugin {
 
       this.emitFile({
         type: 'asset',
-        fileName: manifestFile,
+        fileName: path.basename(manifestPath),
         source: content
       })
     },


### PR DESCRIPTION
In my project I have multiple manifest files, depending on my add-in environment (`local`, `staging`, `production`). I changed the input options to accept a different path for manifest files and also to accept multiple files. It should all be backwards compatible.